### PR TITLE
Add PR preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,67 @@
+name: Preview PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npx vite build --base=/carbon-intensity-app/pr-${{ github.event.pull_request.number }}/
+
+      - name: Deploy Preview
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          destination_dir: pr-${{ github.event.pull_request.number }}
+          keep_files: true
+
+      - name: Comment preview link
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const url = `https://${owner}.github.io/${repo}/pr-${pr}/`;
+            const body = `Preview available: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: pr,
+            });
+            const existing = comments.find(c => c.body && c.body.includes('Preview available:'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr,
+                body,
+              });
+            }
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ npm run dev
 The project includes a GitHub Actions workflow that builds the app and deploys it to **GitHub Pages** whenever changes are pushed to the `main` branch. The built files are served from the `dist` directory with the base path set to `/carbon-intensity-app/`.
 
 To manually trigger a deployment, you can also run the workflow from the GitHub Actions tab.
+
+## Pull Request Previews
+
+When a pull request is opened, a GitHub Actions workflow builds the branch and deploys it to the `gh-pages` branch under `pr-<number>`. The workflow comments on the PR with a link to view the preview.


### PR DESCRIPTION
## Summary
- build a pull request preview with unique base path
- deploy preview to `gh-pages` under a subdirectory for each PR
- comment the PR with a link to the preview
- document pull request previews in README

## Testing
- `npm ci`
- `npm run lint` *(fails: several lint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_b_687ba3cb02b88333b1e3375091c737a0