### PR TITLE
Update deploy workflow to gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,17 +25,9 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm run dev
 
 ## Deployment
 
-The project includes a GitHub Actions workflow that builds the app and deploys it to **GitHub Pages** whenever changes are pushed to the `main` branch. The built files are served from the `dist` directory with the base path set to `/carbon-intensity-app/`.
+The project includes a GitHub Actions workflow that builds the app and pushes the output to the `gh-pages` branch whenever changes are pushed to the `main` branch. Configure GitHub Pages to serve from this branch. The built files are served from the `dist` directory with the base path set to `/carbon-intensity-app/`.
 
 To manually trigger a deployment, you can also run the workflow from the GitHub Actions tab.
 


### PR DESCRIPTION
## Summary
- publish production site with `peaceiris/actions-gh-pages`
- mention gh-pages branch deployment in the README

## Testing
- `npm run lint` *(fails: Lightbulb, Zap etc. unused)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687ba9f111708333937e836b66caa5ff